### PR TITLE
2.0.8 enhanced for Pebble beep support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # WheelLogAndroid
 
-One more try to make it working with Inmotion V8
+Updated Gradle configuration to compile with Gradle 4.4, still a few deprecated statements in there
 
-Added support for Samsung Gear Tizen based watches
+Fixed the Gotway 84V indication issue, the preference change was not processed
+
+Moved the MCM ratio fix for newer MCMs from MainActivity to preference-change processing
+
+Inmotion V8 comms might still be broken, I have no wheel to try it
 
 
 Pebble app code

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WheelLogAndroid
+# WheelLogAndroid V2.0.6
 
 Updated Gradle configuration to compile with Gradle 4.4, still a few deprecated statements in there
 
@@ -8,6 +8,14 @@ Moved the MCM ratio fix for newer MCMs from MainActivity to preference-change pr
 
 Inmotion V8 comms might still be broken, I have no wheel to try it
 
+Revision (A): 
+	Bug fixed: 
+		- The 84V flag was not honored upon Wheellog restart
+	
+	New features:
+		- When the app is in focus, pressing the volume up or down keys will trigger the native wheel beep (KingSong and Gotway)
+		- Pressing the Select button on a connected Pebble watch will trigger the native wheel beep (KingSong and Gotway), if enabled in preferences
+		  This feature might work with a Tizen watch as well, please provide feedback as I don't have access to one
 
 Pebble app code
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,16 @@
-# WheelLogAndroid V2.0.6
+# WheelLogAndroid V2.0.9
 
-Updated Gradle configuration to compile with Gradle 4.4, still a few deprecated statements in there
+Updated Gradle configuration to compile with Gradle 4.4
 
-Fixed the Gotway 84V indication issue, the preference change was not processed
+Inmotion V10 support
 
-Moved the MCM ratio fix for newer MCMs from MainActivity to preference-change processing
+Manual BLE MAC address edit
 
-Inmotion V8 comms might still be broken, I have no wheel to try it
+When the app is in focus, pressing the volume up or down keys will trigger the native wheel beep (KingSong and Gotway)
 
-Revision (A): 
-	Bug fixed: 
-		- The 84V flag was not honored upon Wheellog restart
-	
-	New features:
-		- When the app is in focus, pressing the volume up or down keys will trigger the native wheel beep (KingSong and Gotway)
-		- Pressing the Select button on a connected Pebble watch will trigger the native wheel beep (KingSong and Gotway), if enabled in preferences
-		  This feature might work with a Tizen watch as well, please provide feedback as I don't have access to one
+Pressing the Select button on a connected Pebble watch will trigger the native wheel beep (KingSong and Gotway), if enabled in preferences
+This feature might work with a Tizen watch as well, please provide feedback as I don't have access to one
+
 
 Pebble app code
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         minSdkVersion 18
         targetSdkVersion 25
         versionCode 34
-        versionName "2.0.8a"
+        versionName "2.0.9"
     }
     buildTypes {
         release {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         minSdkVersion 18
         targetSdkVersion 25
         versionCode 34
-        versionName "2.0.6"
+        versionName "2.0.6a"
     }
     buildTypes {
         release {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         minSdkVersion 18
         targetSdkVersion 25
         versionCode 34
-        versionName "2.0.6a"
+        versionName "2.0.8a"
     }
     buildTypes {
         release {
@@ -27,16 +27,16 @@ android {
 //apply plugin: 'android-apt'
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:design:25.1.0'
-    compile 'com.android.support:gridlayout-v7:25.1.0'
-    compile 'com.google.android.gms:play-services-drive:10.0.1'
-    compile 'com.getpebble:pebblekit:3.1.0'
-    compile 'com.github.JakeWharton:ViewPagerIndicator:2.4.1'
-    compile 'com.jakewharton.timber:timber:4.3.1'
-    compile 'com.pavelsikun:material-seekbar-preference:2.3.0+'
-    compile 'com.github.PhilJay:MPAndroidChart:v3.0.0'
-    compile "com.github.hotchemi:permissionsdispatcher:2.2.0"
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.android.support:design:25.1.0'
+    implementation 'com.android.support:gridlayout-v7:25.1.0'
+    implementation 'com.google.android.gms:play-services-drive:10.0.1'
+    implementation 'com.getpebble:pebblekit:3.1.0'
+    implementation 'com.github.JakeWharton:ViewPagerIndicator:2.4.1'
+    implementation 'com.jakewharton.timber:timber:4.3.1'
+    implementation 'com.pavelsikun:material-seekbar-preference:2.3.0+'
+    implementation 'com.github.PhilJay:MPAndroidChart:v3.0.0'
+    implementation "com.github.hotchemi:permissionsdispatcher:2.2.0"
     annotationProcessor 'com.github.hotchemi:permissionsdispatcher-processor:2.2.0'
     //apt "com.github.hotchemi:permissionsdispatcher-processor:2.2.0"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.0"
+    //buildToolsVersion "25.0.0"
 
     lintOptions {
         abortOnError false
@@ -10,10 +10,11 @@ android {
 
     defaultConfig {
         applicationId "com.cooper.wheellog"
+        vectorDrawables.useSupportLibrary = true
         minSdkVersion 18
         targetSdkVersion 25
         versionCode 34
-        versionName "2.0.5"
+        versionName "2.0.6"
     }
     buildTypes {
         release {
@@ -23,7 +24,7 @@ android {
     }
 }
 
-apply plugin: 'android-apt'
+//apply plugin: 'android-apt'
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
@@ -36,5 +37,6 @@ dependencies {
     compile 'com.pavelsikun:material-seekbar-preference:2.3.0+'
     compile 'com.github.PhilJay:MPAndroidChart:v3.0.0'
     compile "com.github.hotchemi:permissionsdispatcher:2.2.0"
-    apt "com.github.hotchemi:permissionsdispatcher-processor:2.2.0"
+    annotationProcessor 'com.github.hotchemi:permissionsdispatcher-processor:2.2.0'
+    //apt "com.github.hotchemi:permissionsdispatcher-processor:2.2.0"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,7 @@ android {
         minSdkVersion 18
         targetSdkVersion 25
         versionCode 34
-        versionName "2.0.4"
+        versionName "2.0.5"
     }
     buildTypes {
         release {

--- a/app/src/main/java/com/cooper/wheellog/BluetoothLeService.java
+++ b/app/src/main/java/com/cooper/wheellog/BluetoothLeService.java
@@ -100,6 +100,10 @@ public class BluetoothLeService extends Service {
                     }
                     break;
                 case Constants.ACTION_REQUEST_KINGSONG_HORN:
+                    WheelData.getInstance().makeWheelBeep();
+                    /* this is type-specific wheel beep code that has been moved to WheelData::makeWheelBeep().
+                       type-specific code has been implemented there.
+
                     if (WheelData.getInstance().getWheelType() == WHEEL_TYPE.KINGSONG) {
                         byte[] data = new byte[20];
                         data[0] = (byte) -86;
@@ -110,6 +114,7 @@ public class BluetoothLeService extends Service {
                         data[19] = (byte) 90;
                         writeBluetoothGattCharacteristic(data);
                     }
+                    */
                     break;
                 case Constants.ACTION_REQUEST_CONNECTION_TOGGLE:
                     if (mConnectionState == STATE_DISCONNECTED)

--- a/app/src/main/java/com/cooper/wheellog/BluetoothLeService.java
+++ b/app/src/main/java/com/cooper/wheellog/BluetoothLeService.java
@@ -162,6 +162,9 @@ public class BluetoothLeService extends Service {
                         autoConnect = true;
                         mBluetoothGatt.close();
                         mBluetoothGatt = mBluetoothGatt.getDevice().connectGatt(BluetoothLeService.this, autoConnect, mGattCallback);
+						if (WheelData.getInstance().getWheelType() == WHEEL_TYPE.INMOTION) {
+                                InMotionAdapter.getInstance().resetConnection();
+                        }
                         broadcastConnectionUpdate(STATE_CONNECTING, true);
                     } else
                         broadcastConnectionUpdate(STATE_CONNECTING, true);

--- a/app/src/main/java/com/cooper/wheellog/MainActivity.java
+++ b/app/src/main/java/com/cooper/wheellog/MainActivity.java
@@ -3,6 +3,8 @@ package com.cooper.wheellog;
 import android.Manifest;
 import android.app.Fragment;
 import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothGattCharacteristic;
+import android.bluetooth.BluetoothGattService;
 import android.bluetooth.BluetoothManager;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
@@ -59,12 +61,14 @@ import com.viewpagerindicator.LinePageIndicator;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Locale;
+import java.util.UUID;
 
 import permissions.dispatcher.NeedsPermission;
 import permissions.dispatcher.OnPermissionDenied;
 import permissions.dispatcher.RuntimePermissions;
 import timber.log.Timber;
 
+import static com.cooper.wheellog.utils.Constants.ACTION_REQUEST_KINGSONG_HORN;
 import static com.cooper.wheellog.utils.MathsUtil.kmToMiles;
 
 
@@ -880,9 +884,25 @@ public class MainActivity extends AppCompatActivity implements GoogleApiClient.O
                 }
                 return true;
             default:
-                return super.onKeyDown(keyCode, event);
+                return super.onKeyDown(keyCode, event); // should this not be super.OnKeyUp() instead?  *MacPara 20180504
         }
     }
+
+
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        if ((keyCode == KeyEvent.KEYCODE_VOLUME_DOWN) ||
+                (keyCode == KeyEvent.KEYCODE_VOLUME_UP))
+        {
+            // Add code to sound the alarm here...
+            WheelData.getInstance().makeWheelBeep();
+            return true;
+        }
+        else
+            return super.onKeyDown(keyCode, event);
+
+    }
+
 
     ViewPager.SimpleOnPageChangeListener pageChangeListener = new ViewPager.SimpleOnPageChangeListener(){
         @Override
@@ -899,6 +919,9 @@ public class MainActivity extends AppCompatActivity implements GoogleApiClient.O
         int max_speed = sharedPreferences.getInt(getString(R.string.max_speed), 30) * 10;
         wheelView.setMaxSpeed(max_speed);
         wheelView.setUseMPH(use_mph);
+        WheelData.getInstance().setUseRatio(sharedPreferences.getBoolean(getString(R.string.use_ratio), false));
+        WheelData.getInstance().setGotway84V(sharedPreferences.getBoolean(getString(R.string.gotway_84v), false));
+
         wheelView.invalidate();
 
         boolean alarms_enabled = sharedPreferences.getBoolean(getString(R.string.alarms_enabled), false);

--- a/app/src/main/java/com/cooper/wheellog/MainActivity.java
+++ b/app/src/main/java/com/cooper/wheellog/MainActivity.java
@@ -902,8 +902,6 @@ public class MainActivity extends AppCompatActivity implements GoogleApiClient.O
         wheelView.invalidate();
 
         boolean alarms_enabled = sharedPreferences.getBoolean(getString(R.string.alarms_enabled), false);
-		boolean use_ratio = sharedPreferences.getBoolean(getString(R.string.use_ratio), false);
-		WheelData.getInstance().setUseRatio(use_ratio);
 		WheelData.getInstance().setAlarmsEnabled(alarms_enabled);
 
         if (alarms_enabled) {

--- a/app/src/main/java/com/cooper/wheellog/MainActivity.java
+++ b/app/src/main/java/com/cooper/wheellog/MainActivity.java
@@ -403,8 +403,8 @@ public class MainActivity extends AppCompatActivity implements GoogleApiClient.O
                 tvCurrent.setVisibility(View.VISIBLE);
                 tvTitlePower.setVisibility(View.VISIBLE);
                 tvPower.setVisibility(View.VISIBLE);
-                tvTitleTemperature2.setVisibility(View.VISIBLE);
-                tvTemperature2.setVisibility(View.VISIBLE);
+                tvTitleTemperature.setVisibility(View.VISIBLE);
+                tvTemperature.setVisibility(View.VISIBLE);
                 tvTitleTotalDistance.setVisibility(View.VISIBLE);
                 tvTotalDistance.setVisibility(View.VISIBLE);
                 break;

--- a/app/src/main/java/com/cooper/wheellog/MainActivity.java
+++ b/app/src/main/java/com/cooper/wheellog/MainActivity.java
@@ -37,6 +37,7 @@ import android.widget.Toast;
 
 import com.cooper.wheellog.utils.Constants;
 import com.cooper.wheellog.utils.Constants.WHEEL_TYPE;
+import com.cooper.wheellog.utils.Constants.ALARM_TYPE;
 import com.cooper.wheellog.utils.SettingsUtil;
 //import com.cooper.wheellog.utils.NotificationUtil;
 import com.cooper.wheellog.utils.Typefaces;
@@ -193,6 +194,18 @@ public class MainActivity extends AppCompatActivity implements GoogleApiClient.O
 					//System.out.println("WheelRecognizedMain");
 					((PreferencesFragment) getPreferencesFragment()).show_main_menu();
 					break;
+				case Constants.ACTION_ALARM_TRIGGERED:					
+					int alarmType = ((ALARM_TYPE) intent.getSerializableExtra(Constants.INTENT_EXTRA_ALARM_TYPE)).getValue();
+					if (alarmType == 0 ) {
+						showSnackBar(getResources().getString(R.string.alarm_text_speed), 3000);						
+					}
+					if (alarmType == 1 ) {
+						showSnackBar(getResources().getString(R.string.alarm_text_current), 3000);						
+					}
+					if (alarmType == 2 ) {
+						showSnackBar(getResources().getString(R.string.alarm_text_temperature), 3000);						
+					}
+					break;
             }
         }
     };
@@ -225,25 +238,6 @@ public class MainActivity extends AppCompatActivity implements GoogleApiClient.O
         setMenuIconStates();
     }
 	
-//	private void applyWheelSettings() {
-//		Timber.i("Apply new wheel settings");
-//		SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(getBaseContext());
-//		boolean ligth_enabled = sharedPreferences.getBoolean(getString(R.string.light_enabled), false);
-//		boolean led_enabled = sharedPreferences.getBoolean(getString(R.string.led_enabled), false);
-//		boolean handle_button_disabled = sharedPreferences.getBoolean(getString(R.string.handle_button_disabled), false);
-//		int max_speed = sharedPreferences.getInt(getString(R.string.wheel_max_speed), 0);
-//		int speaker_volume = sharedPreferences.getInt(getString(R.string.speaker_volume), 0);
-//		int pedals_adjustment = sharedPreferences.getInt(getString(R.string.pedals_adjustment), 0);
-//		WheelData.getInstance().updateLight(ligth_enabled);
-//		WheelData.getInstance().updateLed(led_enabled);
-//		WheelData.getInstance().updateHandleButton(handle_button_disabled);
-//		WheelData.getInstance().updateMaxSpeed(max_speed);
-///		WheelData.getInstance().updateSpeakerVolume(speaker_volume);
-//		WheelData.getInstance().updatePedals(pedals_adjustment);
-//		
-//		
-//		
-//	}
 	
 	private void setWheelPreferences() {
 		Timber.i("SetWheelPreferences");
@@ -1083,7 +1077,8 @@ public class MainActivity extends AppCompatActivity implements GoogleApiClient.O
         intentFilter.addAction(Constants.ACTION_PEBBLE_SERVICE_TOGGLED);
         intentFilter.addAction(Constants.ACTION_PREFERENCE_CHANGED);
 		intentFilter.addAction(Constants.ACTION_WHEEL_SETTING_CHANGED);
-		intentFilter.addAction(Constants.ACTION_WHEEL_TYPE_RECOGNIZED);		
+		intentFilter.addAction(Constants.ACTION_WHEEL_TYPE_RECOGNIZED);	
+		intentFilter.addAction(Constants.ACTION_ALARM_TRIGGERED);			
         return intentFilter;
     }
 

--- a/app/src/main/java/com/cooper/wheellog/PreferencesFragment.java
+++ b/app/src/main/java/com/cooper/wheellog/PreferencesFragment.java
@@ -42,16 +42,19 @@ public class PreferencesFragment extends PreferenceFragment implements SharedPre
 
         // Load the preferences from an XML resource
         addPreferencesFromResource(R.xml.preferences);
-        /*
-        Preference pref = findPreference( "@string/VersionTag" );
+
+        Preference pref = getPreferenceManager().findPreference("@string/VersionTag");
+        if (pref == null) return;
+
         try {
             PackageInfo pInfo = getActivity().getPackageManager().getPackageInfo(getActivity().getPackageName(), 0);
-            String version = pInfo.versionName;
-            pref.setTitle("V"+version);
+            String version = "pInfo";
+            if (pInfo != null) version = "V" + pInfo.versionName;
+            pref.setTitle(version);
         }
-        catch (PackageManager.NameNotFoundException e)
+//        catch (PackageManager.NameNotFoundException e)
+        catch (Exception e)
             { ; }
-        */
     }
 
     @Override

--- a/app/src/main/java/com/cooper/wheellog/PreferencesFragment.java
+++ b/app/src/main/java/com/cooper/wheellog/PreferencesFragment.java
@@ -171,6 +171,14 @@ public class PreferencesFragment extends PreferenceFragment implements SharedPre
 				int led_mode = Integer.parseInt(sharedPreferences.getString(getString(R.string.led_mode), "0"));
 				WheelData.getInstance().updateLedMode(led_mode);
 				break;
+            case "use_ratio":
+                boolean use_ratio = sharedPreferences.getBoolean(getString(R.string.use_ratio), false);
+                WheelData.getInstance().setUseRatio(use_ratio);
+                break;
+            case "gotway_84v":
+                boolean g84v_enabled = sharedPreferences.getBoolean(getString(R.string.gotway_84v), false);
+                WheelData.getInstance().setGotway84V(g84v_enabled);
+                break;
 //			case "reset_user_trip":				
 //				WheelData.getInstance().resetUserDistance();
 //				break;

--- a/app/src/main/java/com/cooper/wheellog/PreferencesFragment.java
+++ b/app/src/main/java/com/cooper/wheellog/PreferencesFragment.java
@@ -3,6 +3,8 @@ package com.cooper.wheellog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.preference.CheckBoxPreference;
 import android.preference.Preference;
@@ -15,8 +17,6 @@ import com.cooper.wheellog.utils.Constants;
 import com.cooper.wheellog.utils.Constants.WHEEL_TYPE;
 import com.cooper.wheellog.utils.SettingsUtil;
 import com.pavelsikun.seekbarpreference.SeekBarPreference;
-
-import timber.log.Timber;
 
 public class PreferencesFragment extends PreferenceFragment implements SharedPreferences.OnSharedPreferenceChangeListener {
 
@@ -39,8 +39,19 @@ public class PreferencesFragment extends PreferenceFragment implements SharedPre
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+
         // Load the preferences from an XML resource
         addPreferencesFromResource(R.xml.preferences);
+        /*
+        Preference pref = findPreference( "@string/VersionTag" );
+        try {
+            PackageInfo pInfo = getActivity().getPackageManager().getPackageInfo(getActivity().getPackageName(), 0);
+            String version = pInfo.versionName;
+            pref.setTitle("V"+version);
+        }
+        catch (PackageManager.NameNotFoundException e)
+            { ; }
+        */
     }
 
     @Override

--- a/app/src/main/java/com/cooper/wheellog/PreferencesFragment.java
+++ b/app/src/main/java/com/cooper/wheellog/PreferencesFragment.java
@@ -12,6 +12,9 @@ import android.preference.PreferenceFragment;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.Toolbar;
 import android.view.View;
+import android.widget.*;
+import android.text.InputType;
+import android.text.TextUtils;
 
 import com.cooper.wheellog.utils.Constants;
 import com.cooper.wheellog.utils.Constants.WHEEL_TYPE;
@@ -43,7 +46,7 @@ public class PreferencesFragment extends PreferenceFragment implements SharedPre
         // Load the preferences from an XML resource
         addPreferencesFromResource(R.xml.preferences);
 
-        Preference pref = getPreferenceManager().findPreference("@string/VersionTag");
+        Preference pref = getPreferenceScreen().findPreference(getString(R.string.VersionTag));
         if (pref == null) return;
 
         try {
@@ -52,7 +55,6 @@ public class PreferencesFragment extends PreferenceFragment implements SharedPre
             if (pInfo != null) version = "V" + pInfo.versionName;
             pref.setTitle(version);
         }
-//        catch (PackageManager.NameNotFoundException e)
         catch (Exception e)
             { ; }
     }
@@ -230,6 +232,7 @@ public class PreferencesFragment extends PreferenceFragment implements SharedPre
 				Preference wheel_button = findPreference(getString(R.string.wheel_settings));
 				Preference reset_top_button = findPreference(getString(R.string.reset_top_speed));
 				Preference reset_user_distance_button = findPreference(getString(R.string.reset_user_distance));
+                Preference last_mac_button = findPreference(getString(R.string.last_mac));
 				//getActivity().sendBroadcast(new Intent(Constants.ACTION_WHEEL_SETTING).putExtra(Constants.INTENT_EXTRA_WHEEL_UPDATE_SCALE, 1));
 
 				
@@ -328,7 +331,67 @@ public class PreferencesFragment extends PreferenceFragment implements SharedPre
                         }
                     });
                 }
-				
+                if (last_mac_button != null) {
+                    last_mac_button.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+                        @Override
+                        public boolean onPreferenceClick(Preference preference) {
+                            AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+                            builder.setTitle("MAC Edit");
+
+                            final EditText input = new EditText(getActivity());
+                            input.setInputType(InputType.TYPE_CLASS_TEXT);
+                            input.setText(SettingsUtil.getLastAddress(getActivity()));
+                            builder.setView(input);
+                            builder.setPositiveButton("OK", new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialog, int which) {
+                                    final String deviceAddress = input.getText().toString();
+                                    SettingsUtil.setLastAddress(getActivity(), deviceAddress);
+                                    AlertDialog.Builder builder1 = new AlertDialog.Builder(getActivity());
+                                    builder1.setTitle("Wheel Password ( InMotion only )");
+
+                                    final EditText input1 = new EditText(getActivity());
+                                    input1.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
+                                    builder1.setView(input1);
+                                    builder1.setPositiveButton("OK", new DialogInterface.OnClickListener() {
+                                        @Override
+                                        public void onClick(DialogInterface dialog, int which) {
+                                            String password = input1.getText().toString();
+                                            //System.out.println("Set password ");
+                                            //System.out.println(password);
+                                            SettingsUtil.setPasswordForWheel(getActivity(), deviceAddress, password);
+                                            password = SettingsUtil.getPasswordForWheel(getActivity(),deviceAddress);
+                                            //System.out.println("Set password ");
+                                            //System.out.println(password);
+                                            //finish();
+                                        }
+                                    });
+                                    builder1.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+                                        @Override
+                                        public void onClick(DialogInterface dialog, int which) {
+                                            dialog.cancel();
+                                            //finish();
+                                        }
+                                    });
+                                    builder1.show();
+
+                                    //SettingsUtil.setPasswordForWheel(getActivity(), deviceAddress, "000000");
+                                    //finish();
+                                }
+                            });
+                            builder.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialog, int which) {
+                                    dialog.cancel();
+                                    //finish();
+                                }
+                            });
+                            builder.show();
+
+                            return true;
+                        }
+                    });
+                }
                 break;
             case Speed:
                 tb.setTitle("Speed Settings");

--- a/app/src/main/java/com/cooper/wheellog/WheelData.java
+++ b/app/src/main/java/com/cooper/wheellog/WheelData.java
@@ -675,6 +675,29 @@ public class WheelData {
 		
     }
 
+    public void makeWheelBeep()
+    {
+        switch (mWheelType)
+        {
+            case GOTWAY:
+                    mBluetoothLeService.writeBluetoothGattCharacteristic("b".getBytes());
+                    break;
+            case INMOTION: break;
+            case KINGSONG:
+                    byte[] data = new byte[20];
+                    data[0] = (byte) 0xaa;
+                    data[1] = (byte)0x55;
+                    data[16] = (byte) 0x88;
+                    data[17] = 0x14;
+                    data[18] = 0x5a;
+                    data[19] = 0x5a;
+                    mBluetoothLeService.writeBluetoothGattCharacteristic(data);
+                break;
+            case NINEBOT:  break;
+            default:
+        }
+    }
+
     private void raiseAlarm(ALARM_TYPE alarmType, Context mContext) {
         Vibrator v = (Vibrator) mContext.getSystemService(Context.VIBRATOR_SERVICE);
         long[] pattern = {0};

--- a/app/src/main/java/com/cooper/wheellog/WheelData.java
+++ b/app/src/main/java/com/cooper/wheellog/WheelData.java
@@ -100,6 +100,12 @@ public class WheelData {
     static void initiate() {
         if (mInstance == null)
             mInstance = new WheelData();
+		else {
+			if (mInstance.ridingTimerControl != null) {
+				mInstance.ridingTimerControl.cancel();
+				mInstance.ridingTimerControl = null;
+			}
+		}
 
         mInstance.full_reset();
 		mInstance.startRidingTimerControl();
@@ -110,7 +116,7 @@ public class WheelData {
         TimerTask timerTask = new TimerTask() {
             @Override
             public void run() {
-                if (mSpeed > RIDING_SPEED) mRidingTime += 1;
+                if (mConnectionState && (mSpeed > RIDING_SPEED)) mRidingTime += 1;
             }
         };
         ridingTimerControl = new Timer();
@@ -545,8 +551,10 @@ public class WheelData {
         return speedAxis;
     }
 
-    void setConnected(boolean connected) {
+    void setConnected(boolean connected) {		
         mConnectionState = connected;
+		
+		if (mWheelType == WHEEL_TYPE.INMOTION) InMotionAdapter.getInstance().resetConnection();
     }
 	
 //	void setUserDistance(long userDistance) {

--- a/app/src/main/java/com/cooper/wheellog/WheelData.java
+++ b/app/src/main/java/com/cooper/wheellog/WheelData.java
@@ -741,7 +741,10 @@ public class WheelData {
     }
 
     private boolean decodeKingSong(byte[] data) {
-
+        if (rideStartTime == 0) {
+            rideStartTime = Calendar.getInstance().getTimeInMillis();
+			mRidingTime = 0;
+		}
         if (data.length >= 20) {
             int a1 = data[0] & 255;
             int a2 = data[1] & 255;
@@ -775,7 +778,8 @@ public class WheelData {
             } else if ((data[16] & 255) == 185) { // Distance/Time/Fan Data
                 long distance = byteArrayInt4(data[2], data[3], data[4], data[5]);
                 setDistance(distance);
-                int currentTime = byteArrayInt2(data[6], data[7]);
+                //int currentTime = byteArrayInt2(data[6], data[7]);
+	            int currentTime = (int) (Calendar.getInstance().getTimeInMillis() - rideStartTime) / 1000;
                 setCurrentTime(currentTime);
                 setTopSpeed(byteArrayInt2(data[8], data[9]));
                 mFanStatus = data[12];
@@ -812,9 +816,10 @@ public class WheelData {
     }
 
     private boolean decodeGotway(byte[] data) {
-        if (rideStartTime == 0)
+        if (rideStartTime == 0) {
             rideStartTime = Calendar.getInstance().getTimeInMillis();
-
+			mRidingTime = 0;
+		}
         if (data.length >= 20) {
             int a1 = data[0] & 255;
             int a2 = data[1] & 255;
@@ -875,8 +880,10 @@ public class WheelData {
     private boolean decodeInmotion(byte[] data) {
         ArrayList<InMotionAdapter.Status> statuses = InMotionAdapter.getInstance().charUpdated(data);
 		if (statuses.size() < 1) return false;
-        if (rideStartTime == 0)
+        if (rideStartTime == 0) {
             rideStartTime = Calendar.getInstance().getTimeInMillis();
+			mRidingTime = 0;
+		}		
         for (InMotionAdapter.Status status: statuses) {
             System.out.println(status.toString());
             if (status instanceof InMotionAdapter.Infos) {

--- a/app/src/main/java/com/cooper/wheellog/WheelData.java
+++ b/app/src/main/java/com/cooper/wheellog/WheelData.java
@@ -93,6 +93,7 @@ public class WheelData {
 	private int mAlarmTemperature = 0;
 	
 	private boolean mUseRatio = false;
+	private boolean mGotway84V = false;
 	private boolean mSpeedAlarmExecuted = false;
     private boolean mCurrentAlarmExecuted = false;
 	private boolean mTemperatureAlarmExecuted = false;
@@ -567,6 +568,11 @@ public class WheelData {
 	
 	void setUseRatio(boolean enabled) {
         mUseRatio = enabled;
+		reset();
+    }
+	
+	void setGotway84V(boolean enabled) {
+        mGotway84V = enabled;
     }
 
     void setPreferences(int alarm1Speed, int alarm1Battery,
@@ -863,7 +869,9 @@ public class WheelData {
                 battery = (mVoltage - 5290) / 13;
             }
             setBatteryPercent(battery);
-
+			if (mGotway84V) {
+				mVoltage = (int)Math.round(mVoltage / 0.8);
+			}
             int currentTime = (int) (Calendar.getInstance().getTimeInMillis() - rideStartTime) / 1000;
             setCurrentTime(currentTime);
 

--- a/app/src/main/java/com/cooper/wheellog/utils/InMotionAdapter.java
+++ b/app/src/main/java/com/cooper/wheellog/utils/InMotionAdapter.java
@@ -70,6 +70,7 @@ public class InMotionAdapter {
         V5F("52", 3812.0d),
         V5FPLUS("53", 3812.0d),
         V8("80", 3812.0d),
+        V10("A0", 3812.0d),
         UNKNOWN("x", 3812.0d);
 
         private String value;
@@ -313,7 +314,7 @@ public class InMotionAdapter {
             } else {
                 batt = 0.0;
             }
-        } else if (model.belongToInputType( "5") || model == Model.V8) {
+        } else if (model.belongToInputType( "5") || model == Model.V8 || model == Model.V10) {
             if (volts > 82.50) {
                 batt = 1.0;
             } else if (volts > 68.0) {
@@ -587,6 +588,7 @@ public class InMotionAdapter {
 				case "52": return "Inmotion V5F";
 				case "53": return "Inmotion V5FPLUS";
 				case "80": return "Inmotion V8";
+                case "A0": return "Inmotion V10";
 				default: return "Unknown";
 			}
         }
@@ -1039,7 +1041,7 @@ public class InMotionAdapter {
 
             if (model.belongToInputType( "1")
                     || model.belongToInputType( "5")
-                    || model == V8) {
+                    || model == V8 || model == V10) {
                 distance = (double) (this.longFromBytes(ex_data, 44)) / 1000.0d;
             } else if (model == R0) {
                 distance = (double) (this.longFromBytes(ex_data, 44)) / 1000.0d;

--- a/app/src/main/java/com/cooper/wheellog/utils/InMotionAdapter.java
+++ b/app/src/main/java/com/cooper/wheellog/utils/InMotionAdapter.java
@@ -1025,9 +1025,9 @@ public class InMotionAdapter {
             double angle = (double) (this.intFromBytes(ex_data, 0)) / 65536.0;
 			double roll = (double) (this.intFromBytes(ex_data, 72)) / 90.0;
             double speed = ((double) (this.signedIntFromBytes(ex_data, 12)) + (double) (this.signedIntFromBytes(ex_data, 16))) / (model.getSpeedCalculationFactor() * 2.0);
-            if (model == R1S || model == R1Sample || model == R0 || model == V8) {
-                speed = Math.abs(speed);
-            }
+            //if (model == R1S || model == R1Sample || model == R0 || model == V8) {
+            speed = Math.abs(speed);
+            //}
             double voltage = (double) (this.intFromBytes(ex_data, 24)) / 100.0;
             double current = (double) (this.signedIntFromBytes(ex_data, 20)) / 100.0;
 			double temperature = ex_data[32] & 0xff;

--- a/app/src/main/java/com/cooper/wheellog/utils/InMotionAdapter.java
+++ b/app/src/main/java/com/cooper/wheellog/utils/InMotionAdapter.java
@@ -175,11 +175,15 @@ public class InMotionAdapter {
             }
         };
         keepAliveTimer = new Timer();
-        keepAliveTimer.scheduleAtFixedRate(timerTask, 0, 200);
+        keepAliveTimer.scheduleAtFixedRate(timerTask, 0, 125);
     }
 	
 	public void setScale(int scale) {
 		updateIntervalScale = scale;
+	}
+	
+	public void resetConnection() {
+		passwordSent = false;
 	}
 	
 	public void setLightState(final boolean lightEnable) {

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -7,7 +7,7 @@
 
     <string-array name="horn_modes">
         <item>Disabled</item>
-        <item>On-board (KingSong)</item>
+        <item>Built-In (KS/GW)</item>
         <item>via bluetooth audio</item>
     </string-array>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,6 +87,7 @@
     <string name="watch_preferences" translatable="false">watch_preferences</string>
     <string name="wheel_settings" translatable="false">wheel_settings</string> 
 	<string name="trip_settings" translatable="false">trip_settings</string>
+    <string name="VersionTag" translatable="false">VersionTag</string>
 
 
     // ALARM PREFERENCES

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -136,5 +136,5 @@
 	// TRIP PREFERENCES
 	<string name="reset_top_speed" translatable="false">reset_top_speed</string>
 	<string name="reset_user_distance" translatable="false">reset_user_distance</string>
-	
+    <string name="last_mac" translatable="false">last_mac</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,8 +49,8 @@
     <string name="voltage">Voltage</string>
     <string name="current">Current</string>
     <string name="power">Power</string>
-    <string name="temperature">Battery temp</string>
-	<string name="temperature2">System temp</string>
+    <string name="temperature">System temp</string>
+	<string name="temperature2">CPU(?) temp</string>
 	<string name="angle">Tilt</string>
 	<string name="roll">Roll</string>
     <string name="fan_status">Fan Status</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,6 +75,11 @@
     <string name="logging_error_all_location_providers_disabled">Location has been disabled within Android. No location data will be logged.</string>
     <string name="raw_distance">Raw Distance</string>
 
+	<string name="alarm_text_speed">Speed alarm triggered</string>
+	<string name="alarm_text_current">Current alarm triggered</string>
+	<string name="alarm_text_temperature">Temperature alarm triggered</string>
+	
+	
     // PREFERENCES
     <string name="speed_preferences" translatable="false">speed_preferences</string>
     <string name="log_preferences" translatable="false">log_preferences</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,7 +38,7 @@
     <string name="waiting_for_wheel">Waiting for wheel…</string>
     <string name="speed">Speed</string>
 	<string name="average_speed">Avg Speed</string>
-	<string name="average_riding_speed">Avg Riding Speed</string>
+	<string name="average_riding_speed">Avg Riding</string>
     <string name="top_speed">Top Speed</string>
     <string name="battery">Battery</string>
     <string name="distance">Distance</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -114,6 +114,7 @@
 	<string name="led_mode" translatable="false">led_mode</string>
 	<string name="start_calibration" translatable="false">start_calibration</string>
 	<string name="alarm_mode" translatable="false">alarm_mode</string>
+	<string name="gotway_84v" translatable="false">gotway_84v</string>
 	
 
     // LOG PREFERENCES

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -40,6 +40,6 @@
     <Preference
         android:key="@string/VersionTag"
         android:enabled="true"
-        android:title="V2.0.6a" />
+        android:title="V2.0.7" />
 
 </PreferenceScreen>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -37,5 +37,9 @@
         android:key="@string/reset_user_distance"
 		android:enabled="true"
         android:title="Reset user distance" />
+    <Preference
+        android:key="@string/VersionTag"
+        android:enabled="true"
+        android:title="V2.0.6a" />
 
 </PreferenceScreen>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -38,8 +38,12 @@
 		android:enabled="true"
         android:title="Reset user distance" />
     <Preference
+        android:key="@string/last_mac"
+        android:enabled="true"
+        android:title="Edit MAC address" />
+    <Preference
         android:key="@string/VersionTag"
         android:enabled="true"
-        android:title="V2.0.7" />
+        android:title="Vx.y.zr" />
 
 </PreferenceScreen>

--- a/app/src/main/res/xml/preferences_gotway.xml
+++ b/app/src/main/res/xml/preferences_gotway.xml
@@ -51,12 +51,12 @@
 		
 	<CheckBoxPreference
         android:key="@string/use_ratio"
-        android:title="My Wheel is Gotway MCM "
-        android:summary="If you wheel is Gotway MCM, and it shows wrong speed, distance and others parameters, it should make them normal" />
+        android:title="My Wheel is a Gotway MCM "
+        android:summary="If your wheel is a Gotway MCM, and it shows wrong speed, distance and others parameters, it should make them normal" />
 
 	<CheckBoxPreference
         android:key="@string/gotway_84v"
-        android:title="My Wheel is Gotway with 84V battery"
-        android:summary="If you wheel is Gotway with 20S (84V) battery" />
+        android:title="My Wheel is a Gotway with 84V battery"
+        android:summary="If your wheel is a Gotway with 20S (84V) battery" />
 		
 </PreferenceScreen>

--- a/app/src/main/res/xml/preferences_gotway.xml
+++ b/app/src/main/res/xml/preferences_gotway.xml
@@ -54,4 +54,9 @@
         android:title="My Wheel is Gotway MCM "
         android:summary="If you wheel is Gotway MCM, and it shows wrong speed, distance and others parameters, it should make them normal" />
 
+	<CheckBoxPreference
+        android:key="@string/gotway_84v"
+        android:title="My Wheel is Gotway with 84V battery"
+        android:summary="If you wheel is Gotway with 20S (84V) battery" />
+		
 </PreferenceScreen>

--- a/app/src/main/res/xml/preferences_gotway.xml
+++ b/app/src/main/res/xml/preferences_gotway.xml
@@ -48,5 +48,10 @@
         android:key="@string/start_calibration"
 		android:enabled="true"
         android:title="Calibration"/>
+		
+	<CheckBoxPreference
+        android:key="@string/use_ratio"
+        android:title="My Wheel is Gotway MCM "
+        android:summary="If you wheel is Gotway MCM, and it shows wrong speed, distance and others parameters, it should make them normal" />
 
 </PreferenceScreen>

--- a/app/src/main/res/xml/preferences_speed.xml
+++ b/app/src/main/res/xml/preferences_speed.xml
@@ -7,11 +7,6 @@
         android:key="@string/use_mph"
         android:title="Use MPH"
         android:summary="Show speed in miles rather than kilometers" />
-	
-	<CheckBoxPreference
-        android:key="@string/use_ratio"
-        android:title="My Wheel is Gotway MCM "
-        android:summary="If you wheel is Gotway MCM, and it shows wrong speed, distance and others parameters, it should make them normal" />
 
     <com.pavelsikun.seekbarpreference.SeekBarPreference
         android:key="@string/max_speed"

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.1.2'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradlew
+++ b/gradlew
@@ -1,46 +1,10 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 ##############################################################################
 ##
 ##  Gradle start up script for UN*X
 ##
 ##############################################################################
-
-# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS=""
-
-APP_NAME="Gradle"
-APP_BASE_NAME=`basename "$0"`
-
-# Use the maximum available, or set MAX_FD != -1 to use that value.
-MAX_FD="maximum"
-
-warn ( ) {
-    echo "$*"
-}
-
-die ( ) {
-    echo
-    echo "$*"
-    echo
-    exit 1
-}
-
-# OS specific support (must be 'true' or 'false').
-cygwin=false
-msys=false
-darwin=false
-case "`uname`" in
-  CYGWIN* )
-    cygwin=true
-    ;;
-  Darwin* )
-    darwin=true
-    ;;
-  MINGW* )
-    msys=true
-    ;;
-esac
 
 # Attempt to set APP_HOME
 # Resolve links: $0 may be a link
@@ -59,6 +23,46 @@ SAVED="`pwd`"
 cd "`dirname \"$PRG\"`/" >/dev/null
 APP_HOME="`pwd -P`"
 cd "$SAVED" >/dev/null
+
+APP_NAME="Gradle"
+APP_BASE_NAME=`basename "$0"`
+
+# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+DEFAULT_JVM_OPTS=""
+
+# Use the maximum available, or set MAX_FD != -1 to use that value.
+MAX_FD="maximum"
+
+warn () {
+    echo "$*"
+}
+
+die () {
+    echo
+    echo "$*"
+    echo
+    exit 1
+}
+
+# OS specific support (must be 'true' or 'false').
+cygwin=false
+msys=false
+darwin=false
+nonstop=false
+case "`uname`" in
+  CYGWIN* )
+    cygwin=true
+    ;;
+  Darwin* )
+    darwin=true
+    ;;
+  MINGW* )
+    msys=true
+    ;;
+  NONSTOP* )
+    nonstop=true
+    ;;
+esac
 
 CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
 
@@ -85,7 +89,7 @@ location of your Java installation."
 fi
 
 # Increase the maximum file descriptors if we can.
-if [ "$cygwin" = "false" -a "$darwin" = "false" ] ; then
+if [ "$cygwin" = "false" -a "$darwin" = "false" -a "$nonstop" = "false" ] ; then
     MAX_FD_LIMIT=`ulimit -H -n`
     if [ $? -eq 0 ] ; then
         if [ "$MAX_FD" = "maximum" -o "$MAX_FD" = "max" ] ; then
@@ -150,11 +154,19 @@ if $cygwin ; then
     esac
 fi
 
-# Split up the JVM_OPTS And GRADLE_OPTS values into an array, following the shell quoting and substitution rules
-function splitJvmOpts() {
-    JVM_OPTS=("$@")
+# Escape application args
+save () {
+    for i do printf %s\\n "$i" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/' \\\\/" ; done
+    echo " "
 }
-eval splitJvmOpts $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS
-JVM_OPTS[${#JVM_OPTS[*]}]="-Dorg.gradle.appname=$APP_BASE_NAME"
+APP_ARGS=$(save "$@")
 
-exec "$JAVACMD" "${JVM_OPTS[@]}" -classpath "$CLASSPATH" org.gradle.wrapper.GradleWrapperMain "$@"
+# Collect all arguments for the java command, following the shell quoting and substitution rules
+eval set -- $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS "\"-Dorg.gradle.appname=$APP_BASE_NAME\"" -classpath "\"$CLASSPATH\"" org.gradle.wrapper.GradleWrapperMain "$APP_ARGS"
+
+# by default we should be in the correct project dir, but when run from Finder on Mac, the cwd is wrong
+if [ "$(uname)" = "Darwin" ] && [ "$HOME" = "$PWD" ]; then
+  cd "$(dirname "$0")"
+fi
+
+exec "$JAVACMD" "$@"

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -8,13 +8,13 @@
 @rem Set local scope for the variables with windows NT shell
 if "%OS%"=="Windows_NT" setlocal
 
-@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-set DEFAULT_JVM_OPTS=
-
 set DIRNAME=%~dp0
 if "%DIRNAME%" == "" set DIRNAME=.
 set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+set DEFAULT_JVM_OPTS=
 
 @rem Find java.exe
 if defined JAVA_HOME goto findJavaFromJavaHome
@@ -46,10 +46,9 @@ echo location of your Java installation.
 goto fail
 
 :init
-@rem Get command-line arguments, handling Windowz variants
+@rem Get command-line arguments, handling Windows variants
 
 if not "%OS%" == "Windows_NT" goto win9xME_args
-if "%@eval[2+2]" == "4" goto 4NT_args
 
 :win9xME_args
 @rem Slurp the command line arguments.
@@ -60,11 +59,6 @@ set _SKIP=2
 if "x%~1" == "x" goto execute
 
 set CMD_LINE_ARGS=%*
-goto execute
-
-:4NT_args
-@rem Get arguments from the 4NT Shell from JP Software
-set CMD_LINE_ARGS=%$
 
 :execute
 @rem Setup the command line


### PR DESCRIPTION
We developed in parallel it seemed, so this is a bit trickier than before. I tried to merge all your recent 2.0.8 enhancements into my code base so I wouldn't undo anything you have done. This should contain V10 support, MAC address edit, etc.  
I had added Pebble beep support for  GW wheels (KS support existed before). 
Also added a version number in the settings preferences page, that updates from the app gradle settings, so it would be easier for folks to check what version they're running. 