### PR TITLE
Fix usage of carriage returns in csv exports to google drive

### DIFF
--- a/app/src/main/java/com/cooper/wheellog/GoogleDriveService.java
+++ b/app/src/main/java/com/cooper/wheellog/GoogleDriveService.java
@@ -197,7 +197,7 @@ public class GoogleDriveService extends Service implements GoogleApiClient.Conne
                         String line;
 
                         while ((line = br.readLine()) != null)
-                            writer.append(line).append('\r');
+                            writer.append(line).append('\n');
 
                         br.close();
                         writer.close();


### PR DESCRIPTION
Fixes https://github.com/JumpMaster/WheelLogAndroid/issues/8