### PR TITLE
Fix rockwheel detection

### DIFF
--- a/app/src/main/java/com/cooper/wheellog/WheelData.java
+++ b/app/src/main/java/com/cooper/wheellog/WheelData.java
@@ -855,7 +855,7 @@ public class WheelData {
                 int battery;
 
 
-                if ((mModel.compareTo("KS-18L") == 0) || (mBtName.compareTo("RW") == 0 )) {
+                if ((mModel.compareTo("KS-18L") == 0) || (mBtName.compareTo("RW") == 0) || (mName.startsWith("ROCKW"))) {
 
                     if (mVoltage > 8350) {
                         battery = 100;
@@ -1206,7 +1206,7 @@ public class WheelData {
 				mContext.sendBroadcast(intent);
 				Timber.i("Protocol recognized as %s", wheel_Type);
 				//System.out.println("WheelRecognizedWD");
-                if (mContext.getResources().getString(R.string.gotway).equals(wheel_Type) && (mBtName.equals("RW"))) {
+                if (mContext.getResources().getString(R.string.gotway).equals(wheel_Type) && (mBtName.equals("RW") || mName.startsWith("ROCKW"))) {
                     Timber.i("It seems to be RochWheel, force to Kingsong proto");
                     wheel_Type = mContext.getResources().getString(R.string.kingsong);
                 }


### PR DESCRIPTION
`mBtName` isn't populated (is an empty string) if we don't start from a fresh
bluetooth pairing with the GT16, so the battery gauge is wrongly calculated
based on a 67.2V battery instead.

Instead, check `mName` for a `"ROCKW"` prefix, as this is available even on
subsequent sessions.